### PR TITLE
Route to single entrance when selected from geocoding

### DIFF
--- a/src/map-style.ts
+++ b/src/map-style.ts
@@ -15,6 +15,7 @@ export const routePointLayer = {
   id: "route-point",
   type: "circle",
   paint: {
+    "circle-opacity": ["coalesce", ["get", "opacity"], 1] as Expression,
     "circle-radius": 5,
     "circle-color": ["get", "color"] as Expression,
   },

--- a/src/overpass.ts
+++ b/src/overpass.ts
@@ -52,10 +52,10 @@ const buildEntranceQuery = (lat: number, lon: number): string => `
 `;
 
 export const queryEntrances = (
-  latLng: [number, number]
+  target: ElementWithCoordinates
 ): Promise<ElementWithCoordinates[]> => {
   const url = new URL("https://overpass-api.de/api/interpreter");
-  url.searchParams.append("data", buildEntranceQuery(latLng[0], latLng[1]));
+  url.searchParams.append("data", buildEntranceQuery(target.lat, target.lon));
   return fetch(url.toString()).then((response) =>
     response.json().then((body: OverpassResponse) => {
       const targets = body.elements.filter(

--- a/src/overpass.ts
+++ b/src/overpass.ts
@@ -14,7 +14,7 @@ export type Element =
   | ElementWithCoordinates
   | (ElementCore & Partial<Coordinates>);
 
-type ElementWithCoordinates = ElementCore & Coordinates;
+export type ElementWithCoordinates = ElementCore & Coordinates;
 
 interface ElementCore {
   type: string;

--- a/src/planner.ts
+++ b/src/planner.ts
@@ -74,6 +74,7 @@ function extractGeometry(
 export function geometryToGeoJSON(
   origin?: [number, number],
   targets?: Array<ElementWithCoordinates>,
+  entrances?: Array<ElementWithCoordinates>,
   coordinates?: Array<[number, number]>,
   obstacles?: Array<[number, number]>,
   obstacleWays?: Array<Array<[number, number]>>
@@ -101,7 +102,22 @@ export function geometryToGeoJSON(
         },
         properties: {
           color: "#64be14",
-          ref: target.tags?.["ref"] || target.tags?.["addr:unit"],
+        },
+      });
+    });
+  }
+  if (entrances) {
+    entrances.forEach((entrance) => {
+      features.push({
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [entrance.lon, entrance.lat],
+        },
+        properties: {
+          color: "#00ffff00",
+          ref: entrance.tags?.["ref"] || entrance.tags?.["addr:unit"],
+          opacity: 0,
         },
       });
     });
@@ -177,6 +193,7 @@ export default function calculatePlan(
         const geoJSON = geometryToGeoJSON(
           origin,
           [target],
+          undefined,
           geometry,
           obstacles,
           obstacleWays

--- a/src/planner.ts
+++ b/src/planner.ts
@@ -1,9 +1,14 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { FeatureCollection } from "geojson";
+import {
+  Feature,
+  FeatureCollection,
+  Geometry,
+  GeoJsonProperties,
+} from "geojson";
 
 import { Planner } from "./planner-config";
 
-import { queryEntrances } from "./overpass";
+import { ElementWithCoordinates } from "./overpass";
 
 function extractGeometry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -67,118 +72,116 @@ function extractGeometry(
 }
 
 export function geometryToGeoJSON(
-  origin: [number, number],
-  destination: [number, number],
-  destinationRef?: string,
+  origin?: [number, number],
+  targets?: Array<ElementWithCoordinates>,
   coordinates?: Array<[number, number]>,
   obstacles?: Array<[number, number]>,
   obstacleWays?: Array<Array<[number, number]>>
 ): FeatureCollection {
-  return {
-    type: "FeatureCollection",
-    features: [
-      {
-        type: "Feature",
-        geometry: {
-          type: "LineString",
-          coordinates: coordinates || [],
-        },
-        properties: {
-          color: "#000",
-        },
+  const features = [] as Array<Feature<Geometry, GeoJsonProperties>>;
+  if (origin) {
+    features.push({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [origin[1], origin[0]],
       },
-      {
-        type: "Feature",
-        geometry: {
-          type: "MultiLineString",
-          coordinates: obstacleWays || [],
-        },
-        properties: {
-          color: "#dc0451",
-          opacity: 1,
-        },
+      properties: {
+        color: "#00afff",
       },
-      {
-        type: "Feature",
-        geometry: {
-          type: "MultiPoint",
-          coordinates: obstacles || [],
-        },
-        properties: {
-          color: "#dc0451",
-          ref: "!",
-        },
-      },
-      {
+    });
+  }
+  if (targets) {
+    targets.forEach((target) => {
+      features.push({
         type: "Feature",
         geometry: {
           type: "Point",
-          coordinates: [origin[1], origin[0]],
-        },
-        properties: {
-          color: "#00afff",
-        },
-      },
-      {
-        type: "Feature",
-        geometry: {
-          type: "Point",
-          coordinates: [destination[1], destination[0]],
+          coordinates: [target.lon, target.lat],
         },
         properties: {
           color: "#64be14",
-          ref: destinationRef,
+          ref: target.tags?.["ref"] || target.tags?.["addr:unit"],
         },
+      });
+    });
+  }
+  if (coordinates) {
+    features.push({
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates,
       },
-    ],
+      properties: {
+        color: "#000",
+      },
+    });
+  }
+  if (obstacleWays) {
+    features.push({
+      type: "Feature",
+      geometry: {
+        type: "MultiLineString",
+        coordinates: obstacleWays,
+      },
+      properties: {
+        color: "#dc0451",
+        opacity: 1,
+      },
+    });
+  }
+  if (obstacles) {
+    features.push({
+      type: "Feature",
+      geometry: {
+        type: "MultiPoint",
+        coordinates: obstacles,
+      },
+      properties: {
+        color: "#dc0451",
+        ref: "!",
+      },
+    });
+  }
+  return {
+    type: "FeatureCollection",
+    features,
   };
 }
 
 export default function calculatePlan(
   origin: [number, number],
-  destination: [number, number],
+  targets: Array<ElementWithCoordinates>,
   callback: (f: FeatureCollection) => void
 ): void {
-  queryEntrances(destination)
-    .then((entrances) => {
-      if (!entrances.length) {
-        return [
-          { id: -1, type: "node", lat: destination[0], lon: destination[1] },
-        ];
-      }
-      return entrances;
-    })
-    .then((targets) => {
-      targets.forEach((target) => {
-        const planner = new Planner();
-        // XXX setProfileID requires URL to start with scheme, so guess
-        const protocol =
-          process.env.NODE_ENV === "production" ? "https" : "http";
-        planner
-          .setProfileID(`${protocol}://${process.env.PUBLIC_URL}/delivery.json`)
-          .query({
-            from: { latitude: origin[0], longitude: origin[1] },
-            to: { latitude: target.lat, longitude: target.lon },
-          })
-          .take(1)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .on("data", async (path: any) => {
-            const completePath = await planner.completePath(path);
-            // eslint-disable-next-line no-console
-            console.log("Plan", completePath, "from", origin, "to", target);
-            const [geometry, obstacles, obstacleWays] = extractGeometry(
-              completePath
-            );
-            const geoJSON = geometryToGeoJSON(
-              origin,
-              [target.lat, target.lon],
-              target.tags?.["ref"] || target.tags?.["addr:unit"],
-              geometry,
-              obstacles,
-              obstacleWays
-            );
-            callback(geoJSON);
-          });
+  targets.forEach((target) => {
+    const planner = new Planner();
+    // XXX setProfileID requires URL to start with scheme, so guess
+    const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
+    planner
+      .setProfileID(`${protocol}://${process.env.PUBLIC_URL}/delivery.json`)
+      .query({
+        from: { latitude: origin[0], longitude: origin[1] },
+        to: { latitude: target.lat, longitude: target.lon },
+      })
+      .take(1)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .on("data", async (path: any) => {
+        const completePath = await planner.completePath(path);
+        // eslint-disable-next-line no-console
+        console.log("Plan", completePath, "from", origin, "to", target);
+        const [geometry, obstacles, obstacleWays] = extractGeometry(
+          completePath
+        );
+        const geoJSON = geometryToGeoJSON(
+          origin,
+          [target],
+          geometry,
+          obstacles,
+          obstacleWays
+        );
+        callback(geoJSON);
       });
-    });
+  });
 }


### PR DESCRIPTION
Reading this PR again, I can see that the commits became larger refactorings than I intended.

Summary of the contents:
* Commit 1: "Query the Overpass API only when destination changes"
  * The list of entrances becomes part of State (type `Array<ElementWithCoordinates>`)
  * Overpass is called directly from `App.ts`, not via `planner.ts`
  * Overpass is called (only) when the destination marker moves (`state.destination`)
  * If there are no Overpass results, a dummy destination entrance with the coordinates of `state.destination` is created
  * In `planner.ts`, `calculatePlan` is called with a list of entrances (type `Array<ElementWithCoordinates>`)
  * Analogously, `geometryToGeoJSON` takes a list of destination entrances (again, type `Array<ElementWithCoordinates>`) instead of destination coordinates
  * All `geometryToGeoJSON`arguments are made optional, so it can also be called to get an empty route layer or intermediate states such as when we have the entrances but no route results yet

* Commit 2: "Route to single entrance when selected from geocoding"
  * Type of `State.destination` changes from coordinates to `ElementWithCoordinates` so that it can refer to a chosen entrance (that the destination marker points at)
  * When the user picks an entrance from the geocoding results, set the destination as the `ElementWithCoordinates` (with OSM id from Pelias) instead of just the coordinates.
  * Before calling `calculatePlan`, check if `state.destination` is one of `state.entrances` and if so, pass only this single entrance in the routing request.
  * `geometryToGeoJSON` gets one more optional argument `entrances` so that it can visualise all the entrances separately from the targets which might be just a single entrance.
  * An entrance which is not a target is visualised without a green dot (opacity 0).

Should I spend some time splitting the commits - perhaps?