### PR TITLE
Update react-autosuggest-geocoder

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10854,7 +10854,7 @@ react-app-polyfill@^1.0.6:
 
 react-autosuggest-geocoder@gatesolve/react-autosuggest-geocoder#fix/modify-for-gatesolve:
   version "1.0.1"
-  resolved "https://codeload.github.com/gatesolve/react-autosuggest-geocoder/tar.gz/dddee8938b409e5194cf5bb21c95f42e8477411c"
+  resolved "https://codeload.github.com/gatesolve/react-autosuggest-geocoder/tar.gz/4db2a4ebcb0e1ea316dddd809ac039a2a52e846b"
   dependencies:
     lodash "^4.17.15"
     node-fetch "^2.6.0"
@@ -10862,13 +10862,15 @@ react-autosuggest-geocoder@gatesolve/react-autosuggest-geocoder#fix/modify-for-g
     react-autosuggest "^10.0.0"
 
 react-autosuggest@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-10.0.0.tgz#49c69a5053d7b98b14f28716875883d11c95e945"
-  integrity sha512-WFCeRuYv6YCY9Ch4BodXPASWJXDh32ehQQHA2eLNhOBhu3Xcank+5W4wcEN+oqdAX1fvKROZRQRF2fpNZaZaxA==
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-10.0.1.tgz#620fab9f203821d407246b74e557cc0605061eda"
+  integrity sha512-Y3vsgN2KKV0pwcKYiIwf2LPzfFxkShebJon9G4yeXE7ToZEY7MDmCNSEI9eKbZzeUAE3mcSpZy5Ho0NTU5NzrA==
   dependencies:
     es6-promise "^4.2.8"
     prop-types "^15.7.2"
     react-autowhatever "^10.2.1"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
     shallow-equal "^1.2.1"
 
 react-autowhatever@^10.2.1:


### PR DESCRIPTION
Without changing the checksums in yarn.lock, the update will not take place. `yarn upgrade react-autosuggest-geocoder` also updated react-autosuggest.