### PR TITLE
Refer to Git packages with "https" (yarnpkg/yarn#4734)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "notistack": "^0.9.11",
     "plannerjs": "https://github.com/gatesolve/planner.js#build-for-gatesolve",
     "react": "^16.13.1",
-    "react-autosuggest-geocoder": "gatesolve/react-autosuggest-geocoder#fix/modify-for-gatesolve",
+    "react-autosuggest-geocoder": "https://github.com/gatesolve/react-autosuggest-geocoder#fix/modify-for-gatesolve",
     "react-dom": "^16.13.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11939,9 +11939,9 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
-react-autosuggest-geocoder@gatesolve/react-autosuggest-geocoder#fix/modify-for-gatesolve:
+"react-autosuggest-geocoder@https://github.com/gatesolve/react-autosuggest-geocoder#fix/modify-for-gatesolve":
   version "1.0.1"
-  resolved "https://codeload.github.com/gatesolve/react-autosuggest-geocoder/tar.gz/4db2a4ebcb0e1ea316dddd809ac039a2a52e846b"
+  resolved "https://github.com/gatesolve/react-autosuggest-geocoder#b3856dceeb70b57f3e71a2cfcab8145783b00a1d"
   dependencies:
     lodash "^4.17.15"
     node-fetch "^2.6.0"


### PR DESCRIPTION
Without this, Yarn uses a version from its cache instead of the
version specified in yarn.lock.

Solution: "specifying it as user/repo#SHA does not update as expected
(more details below), but specifying as
https://github.com/user/repo.git#SHA does work as expected."

https://github.com/yarnpkg/yarn/issues/4722#issuecomment-487103935